### PR TITLE
Fix Page Numbers of Numbered Level 1 Headings

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -183,6 +183,7 @@
   pagebreak()
 
   // Content basics
+  show heading.where(level: 1): set text(fill: primary-color)
   show heading.where(level: 1): it => {
     let is-num = it.numbering != none
 


### PR DESCRIPTION
My try to fix #14 by using pagebreak for numbered level 1 headings.
Feel free to reject or change if it's not the right way of doing things, my typst is not strong...