### PR TITLE
Add Second Examiner to Cover Page

### DIFF
--- a/docs/example-de-thesis.typ
+++ b/docs/example-de-thesis.typ
@@ -60,6 +60,7 @@
     semester: "SoSe2024",
     course: "Templates with Typst",
     examiner: "Prof. Dr.-Ing Mustermann",
+    second-examiner: "Prof. Dr.-Ing Mustermann",
     submission-date: "30.07.2024",
   ),
 

--- a/docs/example-de-thesis.typ
+++ b/docs/example-de-thesis.typ
@@ -60,7 +60,7 @@
     semester: "SoSe2024",
     course: "Templates with Typst",
     examiner: "Prof. Dr.-Ing Mustermann",
-    second-examiner: "Prof. Dr.-Ing Mustermann",
+    second-examiner: "Prof. Dr.-Ing Musterfrau",
     submission-date: "30.07.2024",
   ),
 

--- a/docs/manual-de.typ
+++ b/docs/manual-de.typ
@@ -126,6 +126,7 @@ Wenn bestimmte Dictionaries verwendet werden, muss darauf geachtet werden, dass 
     semester: none,
     course: none,
     examiner: none,
+    second-examiner: none,
     submission-date: none
   ),
 

--- a/docs/manual-en.typ
+++ b/docs/manual-en.typ
@@ -128,6 +128,7 @@ If certain dictionaries are used, care must be taken to ensure that parameters w
     semester: none,
     course: none,
     examiner: none,
+    second-examiner: none,
     submission-date: none
   ),
 

--- a/src/cover_sheet.typ
+++ b/src/cover_sheet.typ
@@ -45,6 +45,7 @@
   semester: none,
   course: none,
   examiner: none,
+  second-examiner: none,
   submission-date: none
 ) = {
   import "utils.typ": *
@@ -242,6 +243,9 @@
       
       [ #get-content(examiner)[ #get-info-description(txt-examiner) ] ],
       [ #get-content(examiner)[ #examiner ] ],
+
+      [ #get-content(second-examiner)[ #get-info-description(txt-second-examiner) ] ],
+      [ #get-content(second-examiner)[ #second-examiner ] ],
       
       [ #get-content(submission-date)[ #get-info-description(txt-submission-date) ] ],
       [ #get-content(submission-date)[ #submission-date ] ],

--- a/src/dictionary.typ
+++ b/src/dictionary.typ
@@ -12,6 +12,7 @@
 #let txt-semester = linguify("semester")
 #let txt-course = linguify("course")
 #let txt-examiner = linguify("examiner")
+#let txt-second-examiner = linguify("second-examiner")
 #let txt-submission-date = linguify("submission-date")
 
 // Declaration on the Final Thesis

--- a/src/lang.toml
+++ b/src/lang.toml
@@ -10,6 +10,7 @@ programme = "Programme"
 semester = "Semester"
 course = "Course"
 examiner = "Examiner"
+second-examiner = "Second Examiner"
 submission-date = "Submission date"
 
 # Declaration on the Final Thesis
@@ -79,6 +80,7 @@ programme = "Studiengang"
 semester = "Semester"
 course = "Kurs"
 examiner = "Prüfer/in"
+second-examiner = "Zweitprüfer/in"
 submission-date = "Abgabedatum"
 
 # Declaration on the Final Thesis

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -65,6 +65,7 @@
     semester: none,
     course: none,
     examiner: none,
+    second-examiner: none,
     submission-date: none
   ),
 
@@ -175,6 +176,7 @@
       semester: if cover-sheet-dict-contains-key("semester") { cover-sheet.semester },
       course: if cover-sheet-dict-contains-key("course") { cover-sheet.course },
       examiner: if cover-sheet-dict-contains-key("examiner") { cover-sheet.examiner },
+      second-examiner: if cover-sheet-dict-contains-key("second-examiner") { cover-sheet.second-examiner },
       submission-date: if cover-sheet-dict-contains-key("submission-date") { cover-sheet.submission-date }
     )
   } else {


### PR DESCRIPTION
For many theses it is required to also have a second examiner. This adds the possibility to display them on the cover page.