### PR TITLE
Option to Disable Backlinks to Abbreviations

### DIFF
--- a/docs/example-de-thesis.typ
+++ b/docs/example-de-thesis.typ
@@ -84,24 +84,27 @@
   show-list-of-figures: false, // Wird trotzdem angezeigt, da es i.d.R. Pflicht ist
   show-list-of-abbreviations: true, // Taucht nur auf, wenn tatsächlich mit gls Abkürzungen im Text aufgerufen werden
   list-of-abbreviations: (
-    (
-      key: "uoats",
-      short: "UOATS",
-      plural: "",
-      long: "University of Applied Typst Sciences",
-      longplural: "",
-      description: [
-        Universität, welche eigentlich nicht existiert
-      ],
-      group: "University",
-    ),
-    (
-      key: "repo-vorlage",
-      short: "aio-studi-and-thesis",
-      long: "Repository der aktuellen Typst-Vorlage",
-      description: [
-        #link("https://github.com/fuchs-fabian/typst-template-aio-studi-and-thesis")
-      ]
+    back-references: true,
+    items: (
+      (
+        key: "uoats",
+        short: "UOATS",
+        plural: "",
+        long: "University of Applied Typst Sciences",
+        longplural: "",
+        description: [
+          Universität, welche eigentlich nicht existiert
+        ],
+        group: "University",
+      ),
+      (
+        key: "repo-vorlage",
+        short: "aio-studi-and-thesis",
+        long: "Repository der aktuellen Typst-Vorlage",
+        description: [
+          #link("https://github.com/fuchs-fabian/typst-template-aio-studi-and-thesis")
+        ]
+      ),
     ),
   ),
   show-list-of-formulas: true,

--- a/docs/manual-de.typ
+++ b/docs/manual-de.typ
@@ -150,13 +150,15 @@ Wenn bestimmte Dictionaries verwendet werden, muss darauf geachtet werden, dass 
   list-of-abbreviations: (
     back-references: true,
     items: (
-      key: "",    // required
-      short: "",  // required
-      plural: "",
-      long: "",
-      longplural: "",
-      description: none,
-      group: "",
+      (
+        key: "",    // required
+        short: "",  // required
+        plural: "",
+        long: "",
+        longplural: "",
+        description: none,
+        group: "",
+      ),
     ),
   ),
   show-list-of-formulas: false,

--- a/docs/manual-de.typ
+++ b/docs/manual-de.typ
@@ -148,7 +148,8 @@ Wenn bestimmte Dictionaries verwendet werden, muss darauf geachtet werden, dass 
   show-list-of-figures: false,
   show-list-of-abbreviations: true,
   list-of-abbreviations: (
-    (
+    back-references: true,
+    items: (
       key: "",    // required
       short: "",  // required
       plural: "",

--- a/docs/manual-en.typ
+++ b/docs/manual-en.typ
@@ -150,7 +150,8 @@ If certain dictionaries are used, care must be taken to ensure that parameters w
   show-list-of-figures: false,
   show-list-of-abbreviations: true,
   list-of-abbreviations: (
-    (
+    back-references: true,
+    items: (
       key: "",    // required
       short: "",  // required
       plural: "",

--- a/docs/manual-en.typ
+++ b/docs/manual-en.typ
@@ -152,13 +152,15 @@ If certain dictionaries are used, care must be taken to ensure that parameters w
   list-of-abbreviations: (
     back-references: true,
     items: (
-      key: "",    // required
-      short: "",  // required
-      plural: "",
-      long: "",
-      longplural: "",
-      description: none,
-      group: "",
+      (
+        key: "",    // required
+        short: "",  // required
+        plural: "",
+        long: "",
+        longplural: "",
+        description: none,
+        group: "",
+      ),
     ),
   ),
   show-list-of-formulas: false,

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -87,14 +87,17 @@
   show-list-of-figures: false,
   show-list-of-abbreviations: true,
   list-of-abbreviations: (
-    (
-      key: "",    // required
-      short: "",  // required
-      plural: "",
-      long: "",
-      longplural: "",
-      description: none,
-      group: "",
+    back-references: true,
+    items: (
+      (
+        key: "",    // required
+        short: "",  // required
+        plural: "",
+        long: "",
+        longplural: "",
+        description: none,
+        group: "",
+      ),
     ),
   ),
   show-list-of-formulas: false,
@@ -316,12 +319,13 @@
 
   // List of Abbreviations
   if show-list-of-abbreviations and is-not-none-or-empty(list-of-abbreviations) {
+    let abbreviations = list-of-abbreviations.items
     show: make-glossary
-    if is-not-none-or-empty(list-of-abbreviations.at(0).key) and is-not-none-or-empty(list-of-abbreviations.at(0).short) {
+    if is-not-none-or-empty(abbreviations.at(0).key) and is-not-none-or-empty(abbreviations.at(0).short) {
       roman-page[
         #heading(depth: 1, bookmarked: true)[ #get-heading-str("list-of-abbreviations") ]
-        #register-glossary(list-of-abbreviations)
-        #print-glossary(list-of-abbreviations)
+        #register-glossary(abbreviations)
+        #print-glossary(abbreviations, disable-back-references: not list-of-abbreviations.back-references)
       ]
     }
   }

--- a/template/main.typ
+++ b/template/main.typ
@@ -88,7 +88,10 @@
   depth-toc: 4,                     // Wenn `thesis-compliant` true ist, dann wird es auf 4 gesetzt wenn hier none steht
   show-list-of-figures: false,      // Wird immer angezeigt, wenn `thesis-compliant` true ist
   show-list-of-abbreviations: true, // Achtung: Schlägt fehl wenn glossary leer ist und trotzdem dargestellt werden soll!
-  list-of-abbreviations: abbreviations(),
+  list-of-abbreviations: (
+    back-references: true,
+    items: abbreviations(),
+  ),
   show-list-of-formulas: true, // Setze es auf false, wenn es nicht angezeigt werden soll
   custom-outlines: ( // none
     (


### PR DESCRIPTION
As per @professionalowo's suggestion in #24, this adds an option to disable back-references like: 
```Typst
list-of-abbreviations : (
  back-references: bool,
  items: array | ...,
)
```