### PR TITLE
Move list of todos into roman numbered section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - BREAKING: Updated `list-of-abbreviations` structure to support back-references (requires `items` wrapper), thanks [@tresonic] (#24)
+- Update the pagination style for `list-of-todos` to use roman numerals (#27)
 
 ### Fixed
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -399,8 +399,8 @@
       todo-outline
     }
     roman-page[
-			#todos()
-		]
+      #todos()
+    ]
   }
 
   // Body

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -387,6 +387,22 @@
     ]
   }
 
+	if show-list-of-todos {
+    let todos() = context {
+      let todo-outline = big-todo.todo_outline
+      let todo-elems = query(todo-outline.target)
+
+      if todo-elems.len() == 0 { return }
+
+      show outline: set heading(outlined: true, depth: 1)
+
+      todo-outline
+    }
+    roman-page[
+			#todos()
+		]
+  }
+
   // Body
   set page(
     footer: if thesis-compliant == false [
@@ -420,20 +436,6 @@
   )
   
   counter(page).update(1)
-
-  let todos() = context {
-    let todo-outline = big-todo.todo_outline
-    let todo-elems = query(todo-outline.target)
-
-    if todo-elems.len() == 0 { return }
-    
-    show outline: set heading(outlined: true, depth: 1)
-    pagebreak(weak: true)
-    todo-outline
-    pagebreak(weak: true)
-  }
-
-  if show-list-of-todos { todos() }
   
   set heading(numbering: "1.1.")
   


### PR DESCRIPTION
This is my try at adressing #27

This also allowed me to fix my not so elegant use of pagebreaks from #21 (sorry)

In the manual it looks like this now (if you show todos):
<img width="649" height="862" alt="image" src="https://github.com/user-attachments/assets/646c3139-51ab-4987-8a61-bb3e2bcb323c" />
